### PR TITLE
fix: Improve error handling in authentication method

### DIFF
--- a/source/Authorization.OAuth2/AuthorizationClient.cs
+++ b/source/Authorization.OAuth2/AuthorizationClient.cs
@@ -147,10 +147,18 @@ namespace Finebits.Authorization.OAuth2
             string error = properties?.Get("error");
             if (!string.IsNullOrEmpty(error))
             {
-                throw new AuthorizationBrokerResultException(
-                    properties: properties,
-                    message: "Authorization cannot be done. The result of the authentication operation contains an error.",
-                    innerException: null);
+                string error_subcode = properties?.Get("error_subcode");
+                if (!string.IsNullOrEmpty(error_subcode) && error_subcode == "cancel")
+                {
+                    throw new OperationCanceledException("The authentication operation was canceled by the user.");
+                }
+                else
+                {
+                    throw new AuthorizationBrokerResultException(
+                        properties: properties,
+                        message: "Authorization cannot be done. The result of the authentication operation contains an error.",
+                        innerException: null);
+                }
             }
 
             if (properties is null || properties.Count == 0)


### PR DESCRIPTION
Added a check for the `error_subcode` in the `ThrowIfAuthenticationUnsuccessful` method of `AuthorizationClient.cs`. If the `error_subcode` is "cancel", an `OperationCanceledException` is thrown to indicate user cancellation. Otherwise, an `AuthorizationBrokerResultException` is thrown for other authentication errors. This change enhances error handling by distinguishing between cancellation and other authentication issues.